### PR TITLE
fix(bridge): add longer timeout to set active tab

### DIFF
--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -526,7 +526,7 @@
                self.currentRoute += '/tabs-' + tab;
                setTimeout(function() {
                    $('#command_bridge_tabs').find('a[href="#tabs-' + tab + '"]').trigger('click');
-               }, 500);
+               }, 1000);
                if (tab === 'graphs') {
                    view.renderGraphs = true;
                }


### PR DESCRIPTION
hack: adding longer timeout to makeup for rare times when DOM is not ready to call the tabs function. 
