### PR TITLE
fix(shipyard): alert user if name is too long

### DIFF
--- a/public/js/src/bridge/copy_shipment_modal.tag
+++ b/public/js/src/bridge/copy_shipment_modal.tag
@@ -45,10 +45,16 @@
 
   saveShipment(evt) {
     var convertedShipment = utils.convertShipment(self.shipment);
-    // Build Shipment
-    self.loading = true;
+    
+    if ((convertedShipment.main.name + '-' + convertedShipment.environment.name).length > 63) {
+        RiotControl.trigger('flash_message', 'error', 'The combination of Shipment and Environment as a name is too long. It must be less than 63 characters.', 30000);
+    } else {
+      // Build Shipment
+      self.loading = true;
+      RiotControl.trigger('bridge_create_shipment', convertedShipment);
+    }
+    
     self.errors = null;
-    RiotControl.trigger('bridge_create_shipment', convertedShipment);
     evt.stopPropagation();
   }
 

--- a/public/js/src/shipyard/confirm.tag
+++ b/public/js/src/shipyard/confirm.tag
@@ -116,6 +116,11 @@
             RiotControl.trigger('flash_message', 'error', 'There are no containers on this shipment.', 30000);
             self.good = false;
         }
+        
+        if ((self.shipment.main.name + '-' + self.shipment.environment.name).length > 63) {
+            RiotControl.trigger('flash_message', 'error', 'The combination of Shipment and Environment as a name is too long. It must be less than 63 characters.', 30000);
+            self.good = false;
+        }
 
         self.update();
     }


### PR DESCRIPTION
closes https://github.com/turnerlabs/harbor-ui/issues/1

This helps the user know if they are creating a shipment which contains a name that is too long. More fixes need to go into shipit and trigger for this scenario, but for now this solves a problem, our users are seeing. 
