### PR TITLE
Load Balancer Status

### DIFF
--- a/public/js/src/appstore.tag
+++ b/public/js/src/appstore.tag
@@ -459,9 +459,14 @@ function AppStore(host, services) {
             accepts: 'application/json',
             data: {},
             success: function (result) {
+                d('BuildStore::build_shipment_trigger::success', result);
                 result = JSON.parse(result);
                 RiotControl.trigger('build_shipment_trigger_result', result);
                 RiotControl.trigger('flash_message', 'success', result.message);
+
+                if (result.elb_id) {
+                    RiotControl.trigger('bridge_lb_status_start', shipment, environment, location, result.elb_id);
+                }
             },
             error: function (xhr, status, err) {
                 var error = xhr.responseText || err || 'Failed To Trigger Shipment!';
@@ -475,7 +480,7 @@ function AppStore(host, services) {
     });
 
     self.on('bridge_shipment_trigger', function (shipment, environment, location) {
-        d('BridgeStore::build_shipment_trigger', shipment, environment, location);
+        d('BridgeStore::bridge_shipment_trigger', shipment, environment, location);
 
         $.ajax({
             method: 'POST',
@@ -484,9 +489,14 @@ function AppStore(host, services) {
             accepts: 'application/json',
             data: {},
             success: function (result) {
+                d('BuildStore::bridge_shipment_trigger::success', result);
                 result = JSON.parse(result);
                 RiotControl.trigger('bridge_shipment_trigger_result', result);
                 RiotControl.trigger('flash_message', 'success', result.message);
+
+                if (result.elb_id) {
+                    RiotControl.trigger('bridge_lb_status_start', shipment, environment, location, result.elb_id);
+                }
             },
             error: function (xhr, status, err) {
                 var error = xhr.responseText || err || 'Failed To Trigger Shipment!';
@@ -495,6 +505,26 @@ function AppStore(host, services) {
 
                 RiotControl.trigger('flash_message', 'error', error.message, 30000);
                 RiotControl.trigger('bridge_shipment_trigger_result', {}, error.message);
+            }
+        });
+    });
+
+    self.on('bridge_lb_status', function (shipment, environment, provider, lbName) {
+        d('BridgeStore::bridge_lb_status', shipment, environment, provider, lbName);
+
+        $.ajax({
+            method: 'POST',
+            url: mu(hosts.trigger, 'loadbalancer', 'status', shipment, environment, provider),
+            data: JSON.stringify({name: lbName}),
+            dataType: 'json',
+            contentType: 'application/json',
+            accepts: 'application/json',
+            success: function (result, status, xhr) {
+                d('BridgeStore::bridge_lb_status::success', result, status);
+                RiotControl.trigger('bridge_lb_status_result', result);
+            },
+            error: function (xhr, status, err) {
+                d('BridgeStore::bridge_lb_status::error', err, xhr.responseText || status);
             }
         });
     });

--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -12,6 +12,7 @@
         </div>
     </div>
 
+    <bridge_lb_status></bridge_lb_status>
     <bridge_shipment_status></bridge_shipment_status>
 
     <copy_shipment_modal targetid="copyModal" shipment="{ shipment }"></copy_shipment_modal>

--- a/public/js/src/bridge/bridge_lb_status.tag
+++ b/public/js/src/bridge/bridge_lb_status.tag
@@ -1,0 +1,69 @@
+<bridge_lb_status>
+
+    <div class="row" if="{ showStatus }">
+        <div class="col s12 brown lighten-5 brown-text z-depth-1">
+            <h4>Load Balancer Status</h4>
+            <p>{ lb_status_message }</p>
+            <p>{ lb_status_description }</p>
+
+            <div class="progress">
+                <div class="indeterminate"></div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    var self = this,
+        d = utils.debug;
+
+    self.wait = 1000 * 10;
+    self.showStatus = false;
+    self.lb_status_message = '';
+    self.lb_status_description = '';
+
+    RiotControl.on('bridge_lb_status_result', function (data) {
+        d('bridge_lb_status::bridge_lb_status_result', data);
+        var outOfService = data.instance_states.filter(function (val) { return val.state === 'OutOfService' }),
+            show = outOfService.length > 0;
+
+        self.showStatus = show;
+
+        if (show) {
+            d('bridge_lb_status_result::outOfService', outOfService)
+            d('bridge_lb_status_result::mapped', outOfService.map(function (val) {return val.state}));
+            self.lb_status_message = outOfService
+                .map(function (val) { return val.state; })
+                .reduce(function (prev, cur) { return cur; }, '');
+            self.lb_status_description = outOfService
+                .map(function (val) { return val.description; })
+                .reduce(function (prev, cur) { return cur; }, '');
+
+            setTimeout(function () {
+                if (self.lbName) {
+                    RiotControl.trigger('bridge_lb_status', self.shipment, self.environment, self.provider, self.lbName);
+                }
+            }, self.wait);
+        } else {
+            RiotControl.trigger('bridge_lb_status_stop');
+        }
+    });
+
+    RiotControl.on('bridge_lb_status_start', function (s, e, p, n) {
+        d('bridge_lb_status::bridge_lb_status_start', s, e, p, n)
+        self.shipment    = s;
+        self.environment = e;
+        self.provider    = p;
+        self.lbName      = n;
+
+        RiotControl.trigger('bridge_lb_status', s, e, p, n);
+    });
+
+    RiotControl.on('bridge_lb_status_stop', function () {
+        d('bridge_lb_status::bridge_lb_status_stop')
+        self.shipment    = null;
+        self.environment = null;
+        self.provider    = null;
+        self.lbName      = null;
+    });
+    </script>
+</bridge_lb_status>

--- a/public/js/src/shipyard/create.tag
+++ b/public/js/src/shipyard/create.tag
@@ -32,8 +32,7 @@
 
     <script>
     var self = this,
-        d = utils.debug,
-        timer;
+        d = utils.debug;
 
     self.state;
     self.messages = [];
@@ -89,7 +88,7 @@
         var msg;
 
         if (status === 200 && !data.errors) {
-            msg = 'Created shipment %name %environment, will now attempt to trigger the Shipment.';
+            msg = 'Created shipment %name %environment, will now trigger the Shipment.';
         } else {
             msg = 'Failed to create shipment %name %environment. Status %status. Aborting.';
         }
@@ -139,21 +138,11 @@
     RiotControl.on('build_endpoint_wait_start', function () {
         d('shipyard/create::build_endpoint_wait_start');
 
-        var check = 0;
+        addMessage('Waiting on AWS ELB to be created, this will take several minutes.');
+        addMessage('Please do not access your Shipment until the Load Balancer is ready.');
+        addMessage('Redirecting you to the Command Bridge page in 10 seconds.');
 
-        addMessage('Waiting on AWS Route53 DNS propagation for your new Shipment, this will take five minutes. Please do not refresh this page, but feel free to navigate away.');
-
-        timer = setInterval(function () {
-            // Every 10 secs going to post a little message, after 30 checks, should be good to move along
-            check++;
-            d('shipyard/create::build_endpoint_wait_start::interval-tick(%d of 30)', check);
-
-            if (check > 30) {
-                RiotControl.trigger('build_done');
-            } else {
-                addMessage('Waiting... ' + (check * 10) + ' secs of 300 secs have transpired.');
-            }
-        }, 1000 * 10);
+        RiotControl.trigger('build_done');
     });
 
     /**
@@ -162,11 +151,7 @@
     RiotControl.on('build_done', function () {
         d('shipyard/create::build_done');
 
-        clearInterval(timer);
-
         RiotControl.trigger('clear_state');
-
-        addMessage('Shipment is ready, navigating to Command Bridge in 10 secs.');
 
         setTimeout(function () {
             d('shipyard/trigger::build_done::setTimeout(riot.route)');
@@ -176,7 +161,6 @@
     });
 
     RiotControl.on('app_changed', function () {
-        clearInterval(timer);
         reset();
     });
 


### PR DESCRIPTION
This adds an interval check for if the load balancer is ready after a trigger. It requires that Trigger as the new `/loadbalancer/status/:Shipment/:Environment/:Provider` endpoint.

Closes issue #13 
