### PR TITLE
Making PORT logic a little more bearable

### DIFF
--- a/public/js/src/bridge/bridge_container.tag
+++ b/public/js/src/bridge/bridge_container.tag
@@ -161,11 +161,6 @@
                     portNums++;
                 }
             });
-            if (portNums > 1 && !alerted.primary) {
-                RiotControl.trigger('flash_message', 'error', 'Cannot have more than one primary port across multiple containers.', 30000);
-                valid = false;
-                alerted.primary = true;
-            }
         });
 
         return valid;

--- a/public/js/src/shipyard/shipit_port.tag
+++ b/public/js/src/shipyard/shipit_port.tag
@@ -263,12 +263,15 @@
      */
     setValue(input) {
         var name = input.target.name.replace('_' + self.port.name, '');
-        
-        if (input.target.value) {
+        if (input.target.value || name === 'healthcheck') {
             self.port[name] = input.target.value;
             self.parent.parent.update();
             self.port.value = parseInt(self.port.value);
-            RiotControl.trigger('port_value_changed', self.parent.container, self.port);
+            if (self.port.primary === true && !self.port.healthcheck) {
+                RiotControl.trigger('flash_message', 'Primary Ports must have a healthcheck.', 30000);
+            } else {
+                RiotControl.trigger('port_value_changed', self.parent.container, self.port);
+            }
         }
     }
 

--- a/public/js/src/utils.tag
+++ b/public/js/src/utils.tag
@@ -341,6 +341,8 @@ var utils = (function () {
                         envVar.add = false;
                         shouldSave.save = true;
                         shouldSave.list.push(envVar);
+                    } else if (port.primary === false){
+                        port.healthcheck = "";
                     }
                 }
             });

--- a/public/js/src/utils.tag
+++ b/public/js/src/utils.tag
@@ -337,6 +337,7 @@ var utils = (function () {
                     hasHealthcheck = true;
 
                     if (port.primary === true && port.healthcheck !== envVar.value) {
+                        port.healthcheck = port.healthcheck || '/changeMe';
                         envVar.value = port.healthcheck;
                         envVar.add = false;
                         shouldSave.save = true;


### PR DESCRIPTION
- remove healthchecks from non primary port objects
- never allow more than one primary port
- set default /changeMe healthcheck on new primary ports if not set
