### PR TITLE
always show shipment status

### DIFF
--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -31,6 +31,13 @@
     </div>
 
     <div id="tabs-overview">
+        <div class="row">
+            <div class="col s10">&nbsp;</div>
+            <div class="col s2 right-align valign">
+                <button class="btn trigger-env-var-btn" onclick="{ triggerShipment }">Trigger</button>
+            </div>
+        </div>
+
         <h4>Service</h4>
         <div class="row">
             <div each={ service in shipment.providers.map(getViewServices) }>
@@ -56,7 +63,7 @@
             </div>
         </div>
 
-        <h4>Replicas</h4>
+        <h4>Provider Information</h4>
         <div each={ service in shipment.providers.map(getViewServices) }>
             <bridge_providers shipment="{ parent.shipment }" service="{ service }"></bridge_providers>
         </div>
@@ -70,6 +77,9 @@
             </div>
             <button class="btn" onclick="{addProvider}">Add Ec2 as a Provider</button>
         </div>
+
+        <h4>Shipment Status</h4>
+        <container_status></container_status>
 
         <h4>Group</h4>
         <p>The group value of your Shipment impacts who is authorized to make edits to all Environments

--- a/public/js/src/bridge/bridge_containers.tag
+++ b/public/js/src/bridge/bridge_containers.tag
@@ -6,7 +6,7 @@
             <label for="edit-btn-containers">Edit mode</label>
         </div>
         <div class="col s2 right-align valign">
-            <button class="btn trigger-containers-btn btn-disable" disabled={ onlyread } onclick="{ triggerShipment }">Trigger</button>
+            <button class="btn trigger-containers-btn" onclick="{ triggerShipment }">Trigger</button>
         </div>
     </div>
 

--- a/public/js/src/bridge/bridge_env_vars.tag
+++ b/public/js/src/bridge/bridge_env_vars.tag
@@ -6,7 +6,7 @@
             <label for="edit-btn-env-var">Edit mode</label>
         </div>
         <div class="col s2 right-align valign">
-            <button class="btn trigger-env-var-btn btn-disable" disabled onclick="{ triggerShipment }">Trigger</button>
+            <button class="btn trigger-env-var-btn" onclick="{ triggerShipment }">Trigger</button>
         </div>
     </div>
 

--- a/public/js/src/bridge/bridge_providers.tag
+++ b/public/js/src/bridge/bridge_providers.tag
@@ -1,28 +1,23 @@
 <bridge_providers>
-    <div class="row valign-wrapper">
-          <p class="col s4 valign">
-              <strong>Replicas:</strong>
-          </p>
-          <p class="col s4 valign"></p>
-          <p class="col s4 valign center-align">
-              <input
-                  class="replicas provider-{ service.provider }"
-                  value="{ service.replicas }"
-                  type="number"
-                  min="0"
-                  onchange="{ updateReplicas }"
-              />
-          </p>
-
-    </div>
-    <div class="row valign-wrapper">
-        <p class="col s4 valign">
-            <strong>Barge:</strong>
-        </p>
-        <p class="col s4 valign">{service.barge}</p>
-        <p class="col s4">
+    <div class="row">
+        <div class="col s3">
+            <p><strong>Barge:</strong></p>
+            <p>{ service.barge }</p>
+        </div>
+        <div class="col s6">
+            <p><strong>Select New Barge:</strong></p>
             <select_barge provider="{service}" callback="{updateBarge}" info="{false}"></select_barge>
-        </p>
+        </div>
+        <div class="col s3">
+            <p><strong>Replicas:</strong></p>
+            <p><input
+                class="replicas provider-{ service.provider }"
+                value="{ service.replicas }"
+                type="number"
+                min="0"
+                onchange="{ updateReplicas }"
+            /></p>
+        </div>
     </div>
 
     <script>

--- a/public/js/src/bridge/container_status.tag
+++ b/public/js/src/bridge/container_status.tag
@@ -1,0 +1,92 @@
+<container_status>
+    <loading_elm if="{ !helm }"></loading_elm>
+
+    <div if="{ !helm.error && helm.replicas.length }">
+        <table>
+            <thead>
+                <tr>
+                    <th>Host</th>
+                    <th>Replica</th>
+                    <th>Phase</th>
+                    <th>Container</th>
+                    <th>State</th>
+                    <th>Restarts</th>
+                </tr>
+            </thead>
+
+            <tbody each="{replica in helm.replicas.sort(sortReplicas)}">
+                <tr each="{container in replica.containers.sort(sortContainers)}">
+                    <td>{ replica.host }</td>
+                    <td>{ replica.name }</td>
+                    <td class="{ getColor(replica.phase) }">{ replica.phase }</td>
+                    <td>{ container.id.slice(0, 32) }</td>
+                    <td class="{ getColor(container.state )}">{ container.state }</td>
+                    <td class="{ checkRestarts(container.restartCount) }">{ container.restartCount }</td>
+                </tr>
+            </tbody>
+        </table>
+        <p>The Shipment status at times will show that the phase and state are running, but your
+            Shipment isn't working the way you intended. This is because the information that is
+            being displayed is how the orchestration backend is handling your Shipment. It does not
+            indicate the actual health of your application.</p>
+    </div>
+
+    <div if="{ !helm.replicas.length }">
+        The Shipment has no running replicas.
+    </div>
+
+    <script>
+    var self = this,
+        d = utils.debug;
+
+    self.helm;
+    self.sortReplicas    = utils.sortReplicas;
+    self.sortContainers  = utils.sortContainers;
+
+    getColor(stage) {
+        var clr;
+        switch (stage) {
+        case 'running':
+        case 'succeeded':
+            clr = 'green';
+            break;
+
+        case 'pending':
+            clr = 'amber';
+            break;
+
+        case 'failed':
+            clr = 'red';
+            break;
+
+        case 'unknown':
+        default:
+            clr = 'grey';
+            break;
+        }
+
+        return clr + '-text';
+    }
+
+    checkRestarts(count) {
+        var clr;
+
+        if (count >= 50) {
+            clr = 'red';
+        } else if (count < 50 && count > 10) {
+            clr = 'amber';
+        } else {
+            clr = 'black';
+        }
+
+        return clr + '-text';
+    }
+
+    RiotControl.on('update_logs_result', function (data) {
+        d('bridge/container_status::update_logs_result', data);
+
+        self.helm = data;
+        self.update();
+    });
+    </script>
+</container_status>

--- a/public/js/src/common/select-barge.tag
+++ b/public/js/src/common/select-barge.tag
@@ -1,5 +1,4 @@
 <select_barge>
-  <h5 class="left">Select Barge</h5>
   <div class="col s12 card blue-grey darken-1" if="{info !== false}">
       <div class="card-content white-text">
           Only select a Barge if you don't want to use the default Barge, <strong>{ defaultBarge }</strong>.
@@ -35,12 +34,12 @@
 
           if (!$('.barge-select').hasClass('select2-hidden-accessible') || currentBarge !== self.provider.barge) {
                currentBarge = self.provider.barge;
-               
+
                // push barge if not present on supplied barges list
                if (self.barges.indexOf(currentBarge) === -1) {
                    self.barges.push(currentBarge);
                }
-               
+
                setTimeout(function() {
                    $('.barge-select').select2();
                }, 100);


### PR DESCRIPTION
Add Shipment status to the Overview tab. Show the host, deployment, pod
phase, container id, container state, and restart count.

Add Trigger button to the Overveiw tab. Enable the Trigger button on
all other tabs.

Rearrange the Provider information. Condense the Barge picker and
replica count to one row.
