### PR TITLE
Never tell shipit if it's hidden or not, for better security

### DIFF
--- a/public/js/src/appstore.tag
+++ b/public/js/src/appstore.tag
@@ -292,8 +292,6 @@ function AppStore(host, services) {
             return;
         }
 
-        payload.hidden = (payload.type === 'hidden') || false;
-
         $.ajax({
             method: method ? method : 'PUT',
             url: mu(hosts.shipit, 'v1', 'shipment', url),


### PR DESCRIPTION
There are more changes needed to be made to make this work properly. Since we now have the audit log in the UI, people should not need this as much. 