### PR TITLE
fix(barge): do not allow barge to be changed if shipment is running

### DIFF
--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -507,6 +507,7 @@
             self.disableShipmentBtn = 'disabled';
         }
 
+        RiotControl.trigger('allow_barge_change', self.disableShipmentBtn === '');
         d('bridge/command/overview::checkDeleteButton `%s`', self.disableShipmentBtn);
     }
 
@@ -680,7 +681,7 @@
             }, self.interval);
 
         }
-        
+
         if (self.shipment) {
             var barge = utils.getBarge(self.shipment);
             RiotControl.trigger('update_logs', barge, self.shipment.parentShipment.name, self.shipment.name);

--- a/public/js/src/bridge/bridge_providers.tag
+++ b/public/js/src/bridge/bridge_providers.tag
@@ -1,14 +1,15 @@
 <bridge_providers>
     <div class="row">
         <div class="col s3">
-            <p><strong>Barge:</strong></p>
-            <p>{ service.barge }</p>
+            <h5>{ service.provider }</h5>
+            <p><strong>Barge:</strong> { service.barge }</p>
         </div>
-        <div class="col s6">
+        <div class="col s7">
             <p><strong>Select New Barge:</strong></p>
             <select_barge provider="{service}" callback="{updateBarge}" info="{false}"></select_barge>
+            <p class="grey-text text-lighten-1">Can only change a barge while the Shipment is not running.</p>
         </div>
-        <div class="col s3">
+        <div class="col s2">
             <p><strong>Replicas:</strong></p>
             <p><input
                 class="replicas provider-{ service.provider }"

--- a/public/js/src/common/select-barge.tag
+++ b/public/js/src/common/select-barge.tag
@@ -4,7 +4,7 @@
           Only select a Barge if you don't want to use the default Barge, <strong>{ defaultBarge }</strong>.
       </div>
   </div>
-  <select class="barge-select" onchange={ pickBarge } style="width: 100%">
+  <select class="barge-select" onchange={ pickBarge } style="width: 100%" disabled>
       <option each="{ barge in barges }"
               selected="{ parent.provider.barge === barge }"
               value="{ barge }">{ barge }</option>
@@ -13,6 +13,7 @@
   <script>
 
       var self = this,
+          d = utils.debug,
           currentBarge;
 
       self.defaultBarge = window.config.default_barge;
@@ -26,6 +27,11 @@
               self.callback();
           }
       }
+
+      RiotControl.on('allow_barge_change', function (allowBargeChange) {
+          d('select_barge::allow_barge_change', allowBargeChange);
+          $('.barge-select').attr('disabled', !allowBargeChange);
+      });
 
       self.on('update', function() {
           self.provider = self.opts.provider;


### PR DESCRIPTION
Fix for issue #59 Prevent Barge Changes when Shipment Running.

Pretty simply, we now default disable changing the barge. When we determine that a Shipment is not running, we toggle the barge selector. We just piggyback on the same mechanism that we are using to not allow running Shipments to be deleted.