### PR TITLE
fix(events): show shipment events when they exist

### DIFF
--- a/public/js/src/appstore.tag
+++ b/public/js/src/appstore.tag
@@ -1142,6 +1142,26 @@ function AppStore(host, services) {
         });
     });
 
+    self.on('fetch_shipment_events', function (barge, shipment, environment) {
+        d('HelmItStore::fetch_shipment_events', barge, shipment, environment);
+
+        $.ajax({
+            method: 'GET',
+            url: mu(hosts.helmit, 'shipment', 'events', barge, shipment, environment),
+            dataType: 'json',
+            contentType: 'application/json',
+            accepts: 'application/json',
+            success: function (result, status, xhr) {
+                d('HelmItStore::fetch_shipment_events::success', result, status);
+                RiotControl.trigger('fetch_shipment_events_result', result);
+            },
+            error: function (xhr, status, err) {
+                d('HelmItStore::fetch_shipment_events::error', err, xhr.responseText || status);
+                RiotControl.trigger('fetch_shipment_events_result', { namespace: shipment +'-'+ environment, events: [] });
+            }
+        });
+    });
+
     self.on('fetch_shipment_status_events', function (barge, shipment, environment) {
         d('HelmItStore::fetch_shipment_status_events', barge, shipment, environment);
 

--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -82,6 +82,9 @@
             <button class="btn" onclick="{addProvider}">Add Ec2 as a Provider</button>
         </div>
 
+        <h4>Shipment Events</h4>
+        <shipment_events></shipment_events>
+
         <h4>Shipment Status</h4>
         <container_status></container_status>
 
@@ -551,6 +554,7 @@
         } else {
             RiotControl.trigger('get_helm_details', barge,  self.shipment.parentShipment.name, self.shipment.name);
             RiotControl.trigger('get_shipment_status', self.shipment);
+            RiotControl.trigger('get_shipment_events', self.shipment);
 
             view.shipmentStatus = view.shipmentStatus.replace(':barge', barge);
             view.shipmentEvents = view.shipmentEvents.replace(':barge', barge);

--- a/public/js/src/bridge/bridge_shipment_status.tag
+++ b/public/js/src/bridge/bridge_shipment_status.tag
@@ -59,7 +59,8 @@
 
     <script>
     var self = this,
-        d = utils.debug;
+        d = utils.debug,
+        interval;
 
     self.phase        = '';
     self.events       = [];
@@ -91,7 +92,9 @@
     }
 
     RiotControl.on('shipment_status_clear', function() {
+        d('bridge_shipment_status::shipment_status_clear')
         self.running = true;
+        clearTimeout(interval);
     });
 
     RiotControl.on('get_shipment_status', function (shipment) {
@@ -127,6 +130,11 @@
         if (data.averageRestarts > 50) {
             self.running = false;
         }
+
+        // Check again in one minute
+        interval = setTimeout(function () {
+            RiotControl.trigger('get_shipment_status', self.shipment);
+        }, 1000 * 60);
 
         self.update();
     });

--- a/public/js/src/bridge/container_status.tag
+++ b/public/js/src/bridge/container_status.tag
@@ -8,7 +8,7 @@
           </div>
       </div>
     </div>
-    <div if="{ !helm.error && helm.replicas.length }">
+    <div if="{ !helm.error && helm.replicas.length }" class="status-window">
         <table class="highlight">
             <thead>
                 <tr>
@@ -169,4 +169,10 @@
         self.update();
     });
     </script>
+    <style>
+    .status-window {
+        max-height: 750px;
+        overflow: auto;
+    }
+    </style>
 </container_status>

--- a/public/js/src/bridge/shipment_events.tag
+++ b/public/js/src/bridge/shipment_events.tag
@@ -1,9 +1,10 @@
 <shipment_events>
     <div if="{ running }" class="row">
         <div class="col s12">
-            <p if="{ !show }">There are no event messages at this time.</p>
+            <p if="{ !show }">There are no event messages at this time. Which is an indication that the containers are running smoothly.</p>
+            <p if="{ show }">There are event messages. This could be an indication that there are issues with the Shipment.</p>
             <ul if="{ show }" class="collection">
-                <li each="{ event in events }" class="collection-item { typeToClass(event.type) }">
+                <li each="{ event in events }" class="collection-item { typeToClass(event.type) }" style="padding-right: 85px;">
                     <span class="badge grey lighten-2" >count: { event.count }</span> { event.message }
                 </li>
             </ul>
@@ -29,7 +30,6 @@
             case 'Normal':
                 colors = ''; break;
             case 'Warning':
-                colors = 'amber lighten-3'; break;
             default:
                 colors = 'red lighten-2'; break;
         }

--- a/public/js/src/bridge/shipment_events.tag
+++ b/public/js/src/bridge/shipment_events.tag
@@ -1,0 +1,96 @@
+<shipment_events>
+    <div if="{ running }" class="row">
+        <div class="col s12">
+            <p if="{ !show }">There are no event messages at this time.</p>
+            <ul if="{ show }" class="collection">
+                <li each="{ event in events }" class="collection-item { typeToClass(event.type) }">
+                    <span class="badge grey lighten-2" >count: { event.count }</span> { event.message }
+                </li>
+            </ul>
+            <p if="{ lastRun }" class="grey-text lighten-2">Last check was at { lastRun }.</p>
+        </div>
+    </div>
+    <div if="{ !running && !show }">
+        <loading_elm></loading_elm>
+    </div>
+
+    <script>
+    var self = this,
+        d = utils.debug,
+        interval;
+
+    self.show    = false; // there is data to show
+    self.running = false; // this should be checking on an interval
+
+    self.typeToClass = function (state) {
+        var colors = '';
+
+        switch (state) {
+            case 'Normal':
+                colors = ''; break;
+            case 'Warning':
+                colors = 'amber lighten-3'; break;
+            default:
+                colors = 'red lighten-2'; break;
+        }
+
+        return colors;
+    }
+
+    RiotControl.on('get_shipment_events', function (shipment) {
+        d('bridge/shipment_events::get_shipment_events', shipment);
+        self.running = true;
+        self.shipment = shipment;
+        self.barge = utils.getBarge(shipment);
+
+        // fetch now
+        RiotControl.trigger('fetch_shipment_events', self.barge, shipment.parentShipment.name, shipment.name);
+        // fetch later (5 minutes)
+        interval = setInterval(function () {
+            RiotControl.trigger('fetch_shipment_events', self.barge, shipment.parentShipment.name, shipment.name);
+        }, 1000 * 60 * 5);
+    });
+
+    RiotControl.on('app_changed', function (page, one, two) {
+        if (self.running) {
+            d('bridge/shipment_events::app_changed(turn-off)', page, one, two);
+            clearInterval(interval);
+            self.running = false;
+            self.show = false;
+        }
+        if (page === 'bridge' && two === 'overview' && !self.running && self.shipment) {
+            d('bridge/shipment_events::app_changed(turn-back-on)', page, one, two);
+            RiotControl.trigger('get_shipment_events', self.shipment);
+        }
+    });
+
+    RiotControl.on('fetch_shipment_events_result', function (data) {
+        d('bridge/shipment_events::fetch_shipment_events_result', data);
+
+        self.lastRun = (new Date()).toLocaleString();
+
+        if (data.namespace === self.shipment.parentShipment.name +'-'+ self.shipment.name) {
+            if (data.events.length > 1) {
+                self.show = true;
+
+                self.events = data.events.filter(function (evt) {
+                    return evt.reason !== 'MissingClusterDNS'
+                });
+            }
+            else {
+                self.show = false;
+            }
+        }
+
+        self.update();
+    });
+
+    </script>
+
+    <style scoped>
+    .collection {
+        max-height: 250px;
+        overflow: auto;
+    }
+    </style>
+</shipment_events>


### PR DESCRIPTION
Check if there are events in HelmIt, if they are, display them. Warnings are given a amber color, Errors are given a red color. This check happens every 5 minutes.

Also added a interval check for the Shipment status that appear at the top of the page so that they will clear if the issue clear (without needing a page reload).

![screen shot 2018-01-25 at 4 32 14 pm](https://user-images.githubusercontent.com/60783/35446948-4d001ca8-0284-11e8-872f-76250af37bab.png)

![screen shot 2018-01-25 at 4 32 47 pm](https://user-images.githubusercontent.com/60783/35446959-54e4ecd2-0284-11e8-9d80-f6d9d3031ee0.png)
