### PR TITLE
fix(trigger): disable trigger button on all tabs

### DIFF
--- a/public/js/src/bridge/bridge_containers.tag
+++ b/public/js/src/bridge/bridge_containers.tag
@@ -54,6 +54,8 @@
             return;
         }
 
+        $('.trigger-containers-btn').attr('disabled', true);
+
         self.shipment.providers.forEach(function(provider) {
             var metricMsg = 'bridge.trigger[%s:%e:%p].containers'.replace('%s', self.shipment.parentShipment.name).replace('%e', self.shipment.name).replace('%p', provider.name);
             RiotControl.trigger('send_metric', metricMsg);
@@ -102,6 +104,10 @@
                 self.update();
             }
         }
+    });
+
+    RiotControl.on('bridge_shipment_trigger_result', function (data) {
+        $('.trigger-containers-btn').attr('disabled', false);
     });
 
     self.on('update', function () {

--- a/public/js/src/bridge/bridge_env_vars.tag
+++ b/public/js/src/bridge/bridge_env_vars.tag
@@ -103,13 +103,15 @@
             return;
         }
 
+        // Disable trigger button
+        $('.trigger-env-var-btn').attr('disabled', true);
+
         self.shipment.providers.forEach(function(provider) {
             var metricMsg = 'bridge.trigger[%s:%e:%p].envVars'.replace('%s', self.shipment.parentShipment.name).replace('%e', self.shipment.name).replace('%p', provider.name);
             RiotControl.trigger('send_metric', metricMsg);
             RiotControl.trigger('bridge_shipment_trigger', self.shipment.parentShipment.name, self.shipment.name, provider.name);
         });
 
-        self.triggering = true;
         self.update();
     }
 
@@ -187,6 +189,11 @@
         opts.iterator[opts.index].value = value;
 
         RiotControl.trigger('shipit_update_value', url, data);
+    });
+
+    RiotControl.on('bridge_shipment_trigger_result', function (data) {
+        // Enable trigger button
+        $('.trigger-env-var-btn').attr('disabled', false);
     });
 
     RiotControl.on('environment_variable_delete', function (key, opts) {


### PR DESCRIPTION
Now, when triggering on the Env Var or Containers tabs, the Trigger button with be disabled until a response is returned from Trigger API.

This will help resolve this error… 

+ Failed to update deployment at Operation cannot be fulfilled on deployments.extensions "thedeployment": the object has been modified; please apply your changes to the latest version and try again