### PR TITLE
fix(trigger): toggle trigger buttons across tabs

### DIFF
--- a/public/js/src/bridge/bridge_command.tag
+++ b/public/js/src/bridge/bridge_command.tag
@@ -35,7 +35,7 @@
         <div class="row">
             <div class="col s10">&nbsp;</div>
             <div class="col s2 right-align valign">
-                <a class="{ btn: true, disabled: triggering }" onclick="{ triggerShipment }" title="Will trigger the Shipment">Trigger</a>
+                <button id="trigger-overview-top-btn" class="btn" onclick="{ triggerShipment }" title="Will trigger the Shipment">Trigger</button>
             </div>
         </div>
 
@@ -138,7 +138,7 @@
             </p>
             <p class="col s4">&nbsp;</p>
             <p class="col s2 valign center-align"><a class="btn" onclick="{ showModal }" target="copyModal" title="Clone the current Shipment:Environment to a new Environment">Clone</a><br>&nbsp;</p>
-            <p class="col s2 valign right-align"><a class="{ btn: true, disabled: triggering }" onclick="{ triggerShipment }" title="Will trigger the Shipment">Trigger</a><br>&nbsp;</p>
+            <p class="col s2 valign right-align"><button id="trigger-overview-bottom-btn" class="btn" onclick="{ triggerShipment }" title="Will trigger the Shipment">Trigger</button><br>&nbsp;</p>
         </div>
     </div>
 
@@ -386,6 +386,8 @@
             return;
         }
 
+        RiotControl.trigger('toggle_trigger_buttons', true);
+
         self.shipment.providers.forEach(function(provider) {
             var tooTrigger = true;
             if (provider.replicas === 0) {
@@ -399,7 +401,6 @@
                 var metricMsg = 'bridge.trigger[%s:%e:%p].overview'.replace('%s', self.shipment.parentShipment.name).replace('%e', self.shipment.name).replace('%p', provider.name);
                 RiotControl.trigger('send_metric', metricMsg);
                 RiotControl.trigger('bridge_shipment_trigger', self.shipment.parentShipment.name, self.shipment.name, provider.name);
-                self.triggering = true;
                 self.update();
             }
         });
@@ -481,9 +482,13 @@
         d('bridge/command/overview::checkDeleteButton::end `%s`', self.disableShipmentBtn);
     }
 
-    RiotControl.on('bridge_shipment_trigger_result', function(result, err) {
-        self.triggering = false;
-        self.update();
+    RiotControl.on('toggle_trigger_buttons', function (state) {
+        $('#trigger-overview-top-btn').attr('disabled', state);
+        $('#trigger-overview-bottom-btn').attr('disabled', state);
+    });
+
+    RiotControl.on('bridge_shipment_trigger_result', function (data) {
+        RiotControl.trigger('toggle_trigger_buttons', false);
     });
 
     RiotControl.on('bridge_shipment_scale_result', function(result, err) {

--- a/public/js/src/bridge/bridge_containers.tag
+++ b/public/js/src/bridge/bridge_containers.tag
@@ -6,7 +6,7 @@
             <label for="edit-btn-containers">Edit mode</label>
         </div>
         <div class="col s2 right-align valign">
-            <button class="btn trigger-containers-btn" onclick="{ triggerShipment }">Trigger</button>
+            <button id="trigger-containers-btn" class="btn" onclick="{ triggerShipment }">Trigger</button>
         </div>
     </div>
 
@@ -54,7 +54,7 @@
             return;
         }
 
-        $('.trigger-containers-btn').attr('disabled', true);
+        RiotControl.trigger('toggle_trigger_buttons', true);
 
         self.shipment.providers.forEach(function(provider) {
             var metricMsg = 'bridge.trigger[%s:%e:%p].containers'.replace('%s', self.shipment.parentShipment.name).replace('%e', self.shipment.name).replace('%p', provider.name);
@@ -106,8 +106,12 @@
         }
     });
 
+    RiotControl.on('toggle_trigger_buttons', function (state) {
+        $('#trigger-containers-btn').attr('disabled', state);
+    });
+
     RiotControl.on('bridge_shipment_trigger_result', function (data) {
-        $('.trigger-containers-btn').attr('disabled', false);
+        RiotControl.trigger('toggle_trigger_buttons', false);
     });
 
     self.on('update', function () {

--- a/public/js/src/bridge/bridge_env_vars.tag
+++ b/public/js/src/bridge/bridge_env_vars.tag
@@ -6,7 +6,7 @@
             <label for="edit-btn-env-var">Edit mode</label>
         </div>
         <div class="col s2 right-align valign">
-            <button class="btn trigger-env-var-btn" onclick="{ triggerShipment }">Trigger</button>
+            <button id="trigger-env-var-btn" class="btn" onclick="{ triggerShipment }">Trigger</button>
         </div>
     </div>
 
@@ -104,7 +104,7 @@
         }
 
         // Disable trigger button
-        $('.trigger-env-var-btn').attr('disabled', true);
+        RiotControl.trigger('toggle_trigger_buttons', true);
 
         self.shipment.providers.forEach(function(provider) {
             var metricMsg = 'bridge.trigger[%s:%e:%p].envVars'.replace('%s', self.shipment.parentShipment.name).replace('%e', self.shipment.name).replace('%p', provider.name);
@@ -191,9 +191,12 @@
         RiotControl.trigger('shipit_update_value', url, data);
     });
 
+    RiotControl.on('toggle_trigger_buttons', function (state) {
+        $('#trigger-env-var-btn').attr('disabled', state);
+    });
+
     RiotControl.on('bridge_shipment_trigger_result', function (data) {
-        // Enable trigger button
-        $('.trigger-env-var-btn').attr('disabled', false);
+        RiotControl.trigger('toggle_trigger_buttons', false);
     });
 
     RiotControl.on('environment_variable_delete', function (key, opts) {


### PR DESCRIPTION
Found a couple more places where if you triggered you could trigger again before you should be able to. This fixes both of those scenarios.

+ Trigger then switch tabs, and trigger again
+ Trigger on the Overview tab, press the disabled button