### PR TITLE
Prevent New Build Plans in BuildIt

### DIFF
--- a/public/js/src/buildit/buildit_plans.tag
+++ b/public/js/src/buildit/buildit_plans.tag
@@ -29,13 +29,6 @@
         </div>
     </div>
 
-    <h2> Add a Plan </h2>
-    <div>
-        <buildit_add_plan plan="{ newPlan }" groups="{groups}"></buildit_add_plan>
-        <button disabled="{updating ? true : ''}"  class="btn" onclick="{ addPlan }" >Save</button>
-    </div>
-
-
     <script>
     var self = this,
         d = utils.debug,


### PR DESCRIPTION
Pretty simple, just removes the ability to add new build plans.